### PR TITLE
Forwarded attribute name is added as part of attribute generation in Python HL code.

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -557,7 +557,8 @@ class PythonUtils {
     
     
     def pythonForwardedAttributeClassHL(ForwardedAttribute attr) '''
-«attr.name» = attribute(«setAttrPropertyHL("label", attr.label, true)»
+«attr.name» = attribute(«setAttrPropertyHL("name", attr.name, true)»
+        «setAttrPropertyHL("label", attr.label, true)»
         forwarded=True
     )
     '''


### PR DESCRIPTION
As part of forwarded attribute generation, attribute 'name' along with its 'label' is added in the attribute generation code.